### PR TITLE
update nodejs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
       libpq-dev \
       ruby2.1-dev \
       ruby=1:2.1.5 \
-      nodejs=0.10.29~dfsg-1.1 && \
+      nodejs=0.10.29~dfsg-2 && \
     rm -rf /var/lib/apt/lists/* && \
     gem install bundler --no-ri --no-rdoc
 


### PR DESCRIPTION
docker-compose buildでE: Version '0.10.29~dfsg-1.1' for 'nodejs' was not
foundのエラーが出た為、versionを上げました。
